### PR TITLE
bug fix: bad regex string literals (backslashes must be passed through literally to re.search)

### DIFF
--- a/scripts/generate_names_csv.py
+++ b/scripts/generate_names_csv.py
@@ -51,13 +51,13 @@ class MultipleNamesTXTReader:
         with open(path) as fp:
             for cnt, line in enumerate(fp):
 
-                if re.match('^\s*$', line):
+                if re.match(r'^\s*$', line):
                     continue
 
-                if re.match('^(\s*\|\s*)*$', line):
+                if re.match(r'^(\s*\|\s*)*$', line):
                     continue
 
-                splits = re.search('^([^\:]+)\:(.+)$', line)
+                splits = re.search(r'^([^\:]+)\:(.+)$', line)
                 if splits:
                     groups = splits.groups()
                     core = groups[0].strip()


### PR DESCRIPTION
This defect is producing warnings in Python output about the escape codes being bad:

```
D:\Files\Keith\Retro Gaming\FPGA and Emulation Hardware\MiSTer\github-repos\c0d3h4x0r\Names_MiSTer\scripts\generate_names_csv.py:54: SyntaxWarning: invalid escape sequence '\s'
  if re.match('^\s*$', line):
D:\Files\Keith\Retro Gaming\FPGA and Emulation Hardware\MiSTer\github-repos\c0d3h4x0r\Names_MiSTer\scripts\generate_names_csv.py:57: SyntaxWarning: invalid escape sequence '\s'
  if re.match('^(\s*\|\s*)*$', line):
D:\Files\Keith\Retro Gaming\FPGA and Emulation Hardware\MiSTer\github-repos\c0d3h4x0r\Names_MiSTer\scripts\generate_names_csv.py:60: SyntaxWarning: invalid escape sequence '\:'
  splits = re.search('^([^\:]+)\:(.+)$', line)
```