### PR TITLE
bug fix: always write LF (rather than CRLF) eols, even when running on Windows

### DIFF
--- a/scripts/generate_dbs.py
+++ b/scripts/generate_dbs.py
@@ -65,7 +65,7 @@ def main(sha):
         run_successfully('git rm -rf .github .gitattributes * || true')
 
     for db_name, db in dbs:
-        with open(db_name, 'w+') as f:
+        with open(db_name, 'w+', newline='\n') as f:
             json.dump(db, f, indent=4, sort_keys=True)
 
         if git_push:

--- a/scripts/generate_names_csv.py
+++ b/scripts/generate_names_csv.py
@@ -91,8 +91,8 @@ class NamesCsvGenerator:
 
         big_space_index = 0
 
-        with open(file, 'w+') as csvfile:
-            csvwriter = csv.writer(csvfile, delimiter=self.options["csv_separator"], quotechar=self.options["csv_quote_char"], quoting=csv.QUOTE_MINIMAL)
+        with open(file, 'w+', newline='\n') as csvfile:
+            csvwriter = csv.writer(csvfile, delimiter=self.options["csv_separator"], quotechar=self.options["csv_quote_char"], quoting=csv.QUOTE_MINIMAL, lineterminator='\n')
             for cnt, core in enumerate(self.context["sorted_cores"]):
 
                 if core == self.options["big_space_before_core"]:
@@ -124,7 +124,7 @@ class NamesCsvGenerator:
         return name.ljust(charlimit * 2, self.options["padding_char"])
 
     def count_firstline(self, file, first_row):
-        with open(file, 'w') as csvfile:
+        with open(file, 'w', newline='\n') as csvfile:
             csvwriter = csv.writer(csvfile, delimiter=self.options["csv_separator"], quotechar=self.options["csv_quote_char"], quoting=csv.QUOTE_MINIMAL)
             csvwriter.writerow(first_row)
 

--- a/scripts/generate_names_txt_files.py
+++ b/scripts/generate_names_txt_files.py
@@ -85,7 +85,7 @@ class NamesTXTWriter:
 
         big_space_index = 0
 
-        with open(self.context["output_file"], 'w+') as namesfile:
+        with open(self.context["output_file"], 'w+', newline='\n') as namesfile:
             for cnt, core in enumerate(self.context["cores"]):
 
                 if core == self.options["big_space_before_core"]:


### PR DESCRIPTION
This fixes issue #31.